### PR TITLE
fix race condition when running tests concurrently

### DIFF
--- a/unittest_gtest.py
+++ b/unittest_gtest.py
@@ -194,7 +194,6 @@ class utest(Task.Task):
             fu = getattr(self.generator.bld, 'all_test_paths')
         except AttributeError:
             fu = os.environ.copy()
-            self.generator.bld.all_test_paths = fu
 
             lst = []
             for g in self.generator.bld.groups:
@@ -212,6 +211,7 @@ class utest(Task.Task):
                 add_path(fu, lst, 'LD_LIBRARY_PATH')
             else:
                 add_path(fu, lst, 'LD_LIBRARY_PATH')
+            self.generator.bld.all_test_paths = fu
 
 
         if isinstance(Options.options.checkfilter, str):

--- a/unittestt.py
+++ b/unittestt.py
@@ -194,7 +194,6 @@ class utest(Task.Task):
             fu = getattr(self.generator.bld, 'all_test_paths')
         except AttributeError:
             fu = os.environ.copy()
-            self.generator.bld.all_test_paths = fu
 
             lst = []
             for g in self.generator.bld.groups:
@@ -212,6 +211,7 @@ class utest(Task.Task):
                 add_path(fu, lst, 'LD_LIBRARY_PATH')
             else:
                 add_path(fu, lst, 'LD_LIBRARY_PATH')
+            self.generator.bld.all_test_paths = fu
 
 
         if isinstance(Options.options.checkfilter, str):


### PR DESCRIPTION
A routine copied from `waf_unit_test.py` has a race condition when running tests simultaneously (e.g., `./waf -j 10`).
The part where caching environment variables for unittests is thread-unsafe, as reported [here](https://code.google.com/p/waf/issues/detail?id=1200).
