### PR TITLE
enable ./waf --checkleak without build option

### DIFF
--- a/unittestt.py
+++ b/unittestt.py
@@ -117,7 +117,7 @@ def options(opt):
                    help = 'Execute specified unit test')
     opt.add_option('--checkfilter', action = 'store', default = False,
                    help = 'Execute unit tests sprcified by pattern')
-    opt.add_option('--checkleak', action = 'store', default = False,
+    opt.add_option('--checkleak', action = 'store_true', default = False,
                    help = 'Execute unit tests with valgrind')
 
 def match_filter(filt, targ):


### PR DESCRIPTION
### before

```
$ ./waf --checkleak
waf [commands] [options]

Main commands (example: ./waf build -j4)
  build    : executes the build
  clean    : cleans the project
  configure: configures the project
  dist     : makes a tarball for redistributing the sources
  distcheck: checks if the project compiles (tarball from 'dist')
  distclean: removes the build directory
  install  : installs the targets on the system
  list     : lists the targets to execute
  step     : executes tasks in a step-by-step fashion, for debugging
  uninstall: removes the targets installed
  update   : updates the plugins from the *waflib/extras* directory

waf: error: --checkleak option requires an argument

$ ./waf --checkleak build
(ok)
```

it is a bit inconvenient. `--checkleak` option should be used like `--check` option
### after

```
$ ./waf --checkleak
(ok)
```
